### PR TITLE
Check the file is writeable after the directory walk

### DIFF
--- a/src/codemod.py
+++ b/src/codemod.py
@@ -359,7 +359,8 @@ class Query:
     path_list = Query._walk_directory(self.root_directory)
     path_list = Query._sublist(path_list, start_pos.path, end_pos.path)
     path_list = (path for path in path_list if
-                 Query._path_looks_like_code(path) and self.path_filter(path))
+                 Query._path_looks_like_code(path) and self.path_filter(path)
+                 and os.access(path, os.W_OK))
 
     for path in path_list:
 


### PR DESCRIPTION
This should fix #2.

Not 100% sure if this is a good idea as it may cause un-expected behaviour, due to it quietly skipping files.

It may be better storing doing a try/catch around the open in the _save method, storing the path in a global list then at the end of the script dumping out all the failed files.

It could be outputted after each diff, but due to the way the terminal is used it would easily obscure the stdout, as the next terminal effectively clears previous data.
