### PR TITLE
implement pep-0394

### DIFF
--- a/src/codemod.py
+++ b/src/codemod.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Copyright (c) 2007-2008 Facebook
 #


### PR DESCRIPTION
make it explicit that codemod needs python2,
as it does not run with python3.
according to pep-0394, python distributors are allowed to provide either
python 2 or 3 as `python` command, and should provide `python2` and
`python3` commands to refer to python v2 or 3 respectively.

see http://www.python.org/dev/peps/pep-0394/

without this fix, codemod doesn't run on platforms where `python` is
python3, such as Arch Linux