### PR TITLE
Add exclude_paths

### DIFF
--- a/src/codemod.py
+++ b/src/codemod.py
@@ -56,6 +56,8 @@ Options (all optional) include:
     through, just before which to end.
   --extensions
     A comma-delimited list of file extensions to process.
+  --exclude_paths
+    A comma-delimited list of paths to exclude.
   --editor
     Specify an editor, e.g. "vim" or "emacs".  If omitted, defaults to $EDITOR
     environment variable.
@@ -766,7 +768,8 @@ def _parse_command_line():
   try:
     opts, remaining_args = getopt.gnu_getopt(
         sys.argv[1:], 'md:',
-        ['start=', 'end=', 'extensions=', 'editor=', 'count', 'test'])
+        ['start=', 'end=', 'extensions=', 'exclude_paths=',
+         'editor=', 'count', 'test'])
   except getopt.error:
     raise _UsageException()
   opts = dict(opts)
@@ -790,9 +793,11 @@ def _parse_command_line():
     query_options['end'] = opts['--end']
   if '-d' in opts:
     query_options['root_directory'] = opts['-d']
-  if '--extensions' in opts:
+  if '--extensions' in opts or '--exclude_paths' in opts:
     query_options['path_filter'] = (
-        path_filter(extensions=opts['--extensions'].split(',')))
+        path_filter(extensions=opts['--extensions'].split(',') \
+                    if '--extensions' in opts else None,
+                    exclude_paths=opts.get('--exclude_paths', '').split(',')))
 
   options = {}
   options['query'] = Query(**query_options)

--- a/src/codemod.py
+++ b/src/codemod.py
@@ -98,9 +98,10 @@ def path_filter(extensions=None, exclude_paths=[]):
     if extensions:
       if not any(path.endswith('.' + extension) for extension in extensions):
         return False
-    for excluded in exclude_paths:
-      if path.startswith(excluded) or path.startswith('./' + excluded):
-        return False
+    if exclude_paths:
+      for excluded in exclude_paths:
+        if path.startswith(excluded) or path.startswith('./' + excluded):
+          return False
     return True
   return the_filter
 
@@ -797,7 +798,8 @@ def _parse_command_line():
     query_options['path_filter'] = (
         path_filter(extensions=opts['--extensions'].split(',') \
                     if '--extensions' in opts else None,
-                    exclude_paths=opts.get('--exclude_paths', '').split(',')))
+                    exclude_paths=opts.get['--exclude_paths'].split(',') \
+                    if '--exclude_paths' in opts else None))
 
   options = {}
   options['query'] = Query(**query_options)


### PR DESCRIPTION
Allows specifying a comma-delimited list of paths to exclude.

A more idiomatic UNIXy way might be allowing you to specify `--exclude` multiple times on the command line. If you'd prefer I investigate that, let me know.