### PR TITLE
gh-49 adds test to check if extensions are specified

### DIFF
--- a/src/codemod.py
+++ b/src/codemod.py
@@ -822,6 +822,10 @@ def _parse_command_line():
     doctest.testmod()
     sys.exit(0)
 
+  if (arguments.extensions == None) and (arguments.include_extensionless == False):
+    parser.print_usage()
+    sys.exit(0)
+
   yes_to_all = arguments.accept_all
 
   query_options = {}


### PR DESCRIPTION
Adds a test for the command line arguments, solves the issue with no arguments.