### PR TITLE
Extensions glob matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Options (all optional) include:
       *before* which we should stop exploring, or a percentage of the way
       through, just before which to end.
     --extensions
-      A comma-delimited list of file extensions to process.
+      A comma-delimited list of file extensions to process. Also supports Unix
+      pattern matching.
     --include-extensionless
       If set, this will check files without an extension, along with any
       matching file extensions passed in --extensions

--- a/codemod/base.py
+++ b/codemod/base.py
@@ -71,11 +71,20 @@ def matches_extension(path, extension):
         return fnmatch.fnmatch(ext[1:], extension)
 
 
-def path_filter(extensions=None, exclude_paths=None):
+def path_filter(extensions, exclude_paths=None):
     """
-    Returns a function (useful as the path_filter field of a Query instance)
-    that returns True iff the path it is given has an extension one of the
-    file extensions specified in `extensions`, an array of strings.
+    Returns a function that returns True if a filepath is acceptable.
+
+    @param extensions     An array of strings. Specifies what file
+                          extensions should be accepted by the
+                          filter. If None, we default to the Unix glob
+                          `*` and match every file extension.
+    @param exclude_paths  An array of strings which represents filepaths
+                          that should never be accepted by the filter.
+
+    @return function      A filter function that will only return True
+                          when a filepath is acceptable under the above
+                          conditions.
 
     >>> map(path_filter(extensions=['js', 'php']),
     ...     ['./profile.php', './q.jjs'])
@@ -90,11 +99,9 @@ def path_filter(extensions=None, exclude_paths=None):
     exclude_paths = exclude_paths or []
 
     def the_filter(path):
-        if extensions:
-            if not any(
-                matches_extension(path, extension) for extension in extensions
-            ):
-                return False
+        if not any(matches_extension(path, extension)
+                   for extension in extensions):
+            return False
         if exclude_paths:
             for excluded in exclude_paths:
                 if path.startswith(
@@ -922,7 +929,7 @@ def _parse_command_line():
     parser.add_argument('--extensions', action='store',
                         default='*', type=str,
                         help='A comma-delimited list of file extensions '
-                             'to process. You may also use Unix pattern '
+                             'to process. Also supports Unix pattern '
                              'matching.')
     parser.add_argument('--include-extensionless', action='store_true',
                         help='If set, this will check files without '

--- a/codemod/base.py
+++ b/codemod/base.py
@@ -89,7 +89,8 @@ def path_filter(extensions, exclude_paths=None):
     >>> map(path_filter(extensions=['js', 'php']),
     ...     ['./profile.php', './q.jjs'])
     [True, False]
-    >>> map(path_filter(exclude_paths=['html']),
+    >>> map(path_filter(extensions=['*'],
+    ...                 exclude_paths=['html']),
     ...     ['./html/x.php', './lib/y.js'])
     [False, True]
     >>> map(path_filter(extensions=['js', 'BUILD']),


### PR DESCRIPTION
This PR adds pattern matching to the `--extensions` argument. It also changes the script to not require either one of `--extensions` or `--include-extensionless` in order to run. Instead if `--extensions` is not provided it will always default to the Unix pattern `*`. Includes some code cleanup to support this change.

Open to hearing your thoughts on this. I'm guessing the potentially controversial bit will be defaulting to `*` and not requiring the above args.

The only strange behavior I noticed with this change is that if you are invoking the program with a wildcard extension you need to add a comma for argparse to work:

```
codemod --extensions *  '<match>' '<change>'            -->        fails
codemod --extensions *, '<match>' '<change>'            -->        works fine
```

Not sure how important this is if we keep the default `*` argument though.

This resolves https://github.com/facebook/codemod/issues/30 and https://github.com/facebook/codemod/issues/56. Also, unrelated but https://github.com/facebook/codemod/issues/59 should be closed as it is resolved.