### PR TITLE
Allow exiting the program by pressing 'q' for quit

### DIFF
--- a/codemod/base.py
+++ b/codemod/base.py
@@ -668,16 +668,16 @@ def _ask_about_patch(patch, editor, default_no):
         if not yes_to_all:
             if default_no:
                 print('Accept change (y = yes, n = no [default], e = edit, ' +
-                      'A = yes to all, E = yes+edit)? '),
+                      'A = yes to all, E = yes+edit, q = quit)? '),
             else:
                 print('Accept change (y = yes [default], n = no, e = edit, ' +
-                      'A = yes to all, E = yes+edit)? '),
-            p = _prompt('yneEA', default=default_action)
+                      'A = yes to all, E = yes+edit, q = quit)? '),
+            p = _prompt('yneEAq', default=default_action)
         else:
             p = 'y'
     else:
-        print('(e = edit [default], n = skip line)? ', end=" ")
-        p = _prompt('en', default='e')
+        print('(e = edit [default], n = skip line, q = quit)? ', end=" ")
+        p = _prompt('enq', default='e')
 
     if p in 'A':
         yes_to_all = True
@@ -687,6 +687,8 @@ def _ask_about_patch(patch, editor, default_no):
         _save(patch.path, lines)
     if p in 'eE':
         run_editor(patch.start_position, editor)
+    if p in 'q':
+        sys.exit(0)
 
 
 def _prompt(letters='yn', default=None):


### PR DESCRIPTION
It's always been possible to abort via Ctrl-C, but "q" is quite common for interactive Unix terminal programs and feels less "violent".