### PR TITLE
Exit with usage message when nothing to do

### DIFF
--- a/codemod/base.py
+++ b/codemod/base.py
@@ -963,6 +963,8 @@ def _parse_command_line():
                         help='Substitution to replace with.')
 
     arguments = parser.parse_args()
+    if not arguments.match:
+        parser.exit(0, parser.format_usage())
 
     yes_to_all = arguments.accept_all
 


### PR DESCRIPTION
The program would crash when run without a match argument.
Show the usage message instead and exit cleanly.