### PR TITLE
Use re.MULTILINE instead of re.DOTALL

### DIFF
--- a/codemod/base.py
+++ b/codemod/base.py
@@ -230,9 +230,9 @@ def multiline_regex_suggestor(regex, substitution=None, ignore_case=False):
     """
     if isinstance(regex, str):
         if ignore_case is False:
-            regex = re.compile(regex, re.DOTALL)
+            regex = re.compile(regex, re.MULTILINE)
         else:
-            regex = re.compile(regex, re.DOTALL | re.IGNORECASE)
+            regex = re.compile(regex, re.MULTILINE | re.IGNORECASE)
 
     if isinstance(substitution, str):
         def substitution_func(match):


### PR DESCRIPTION
Not sure which use cases this change breaks, but I found I need the
other mode to also catch trailing newlines when removing rcsids from
old C code with this invocation: codemod -m '^.+?RCSID.+?$\n*'

Or maybe we could add a command line option to choose the multiple line mode?