### PR TITLE
[Formatting] Clean up extra newlines and spaces in suggested patches

### DIFF
--- a/codemod/base.py
+++ b/codemod/base.py
@@ -646,7 +646,7 @@ def print_patch(patch, lines_to_print, file_lines=None):
 
     def print_file_line(line_number):  # noqa
         # Why line_number is passed here?
-        print('  %s' % file_lines[i]) if (
+        print('  %s' % file_lines[i], end='') if (
             0 <= i < len(file_lines)) else '~\n',
 
     for i in range(start_context_line_number, patch.start_line_number):
@@ -839,7 +839,7 @@ def _terminal_use_capability(capability_name):
 def terminal_print(text, color):
     """Print text in the specified color, without a terminating newline."""
     _terminal_set_color(color)
-    print(text, end=" ")
+    print(text, end='')
     _terminal_restore_color()
 
 


### PR DESCRIPTION
Cleans up the formatting of suggested patches by removing spurious newlines in unmodified lines and removing spaces in front of the first line of the contextual snippet and the green "+" line.

Before:
![before](https://cloud.githubusercontent.com/assets/379606/21575824/56a8a296-cecf-11e6-9517-7ef8ea56087f.png)

After:
![after](https://cloud.githubusercontent.com/assets/379606/21575827/5ff5642e-cecf-11e6-8c90-f613c6abb7bb.png)

Test Plan: Run `python setup.py install -f` and run codemod in a directory, output is noticeably cleaner.