### PR TITLE
Don't advance position if substitution is zero-length

### DIFF
--- a/codemod/base.py
+++ b/codemod/base.py
@@ -188,7 +188,8 @@ def multiline_regex_suggestor(regex, substitution=None, ignore_case=False):
                 end_line_number=end_row + 1,
                 new_lines=new_lines
             )
-            pos = match.start() + 1
+            delta = 1 if new_lines is None else min(1, len(new_lines))
+            pos = match.start() + delta
 
     return suggestor
 


### PR DESCRIPTION
Fixes #33. Manually tested example in that issue.

I don't know if substitution functions can return something that doesn't have a `len()` and I'm not really familiar with the library use case, so please give that some thought/review!