### PR TITLE
Attempt to fix unicode error when using python3.x to make test happy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 
 python:
   - "2.7"
+  - "3.6"
 
 install:
-  - "pip install ."
-  - "pip install flake8 pytest"
+  - "pip install -r dev-requirements.txt"
 script: make test
 

--- a/codemod/patch.py
+++ b/codemod/patch.py
@@ -15,7 +15,7 @@ class Patch(object):
     >>> p.apply_to(l)
     >>> l
     ['a', 'b', 'X', 'Y', 'Z', 'e', 'f']
-    >>> print p
+    >>> print(p)
     Patch('x.php', 2, 4, ['X', 'Y', 'Z'])
     """
 

--- a/codemod/terminal_helper.py
+++ b/codemod/terminal_helper.py
@@ -13,6 +13,13 @@ import termios
 import struct
 
 
+def _unicode(s, encoding='utf-8'):
+        if type(s) == bytes:
+            return s.decode(encoding, 'ignore')
+        else:
+            return str(s)
+
+
 def terminal_get_size(default_size=(25, 80)):
     """
     Return (number of rows, number of columns) for the terminal,
@@ -72,7 +79,7 @@ def _terminal_use_capability(capability_name):
     curses.setupterm()
     capability = curses.tigetstr(capability_name)
     if capability:
-        sys.stdout.write(unicode(capability, 'ascii'))
+        sys.stdout.write(_unicode(capability))
     return bool(capability)
 
 
@@ -101,11 +108,11 @@ def _terminal_set_color(color):
         )
     )
     if code:
-        code = unicode(code, 'ascii')
+        code = _unicode(code)
         sys.stdout.write(code)
 
 
 def _terminal_restore_color():
     restore_code = curses.tigetstr('sgr0')
     if restore_code:
-        sys.stdout.write(unicode(restore_code, 'ascii'))
+        sys.stdout.write(_unicode(restore_code))

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,3 @@
+.
+flake8
+pytest


### PR DESCRIPTION
This PR add the following changes:

**Code changes**

- Essay to take a stab at fixing the following unicode error raised below when running codemod `master` branch on python3.x according [pyporting](https://docs.python.org/dev/howto/pyporting.html) guide :

```
(codemod-3.6) % codemod -m -d . --editor vim --extensions="py" -i '(extensions)' 'sbz test replace \1'
Resume where you left off, at ./build/lib/codemod/helpers.py:47 (y/n)?  y
Searching for first instance...
Traceback (most recent call last):
  File "/private/tmp/test/bin/codemod", line 11, in <module>
    load_entry_point('codemod==1.0.0', 'console_scripts', 'codemod')()
  File "/private/tmp/test/lib/python3.6/site-packages/codemod-1.0.0-py3.6.egg/codemod/base.py", line 493, in main
    run_interactive(**options)
  File "/private/tmp/test/lib/python3.6/site-packages/codemod-1.0.0-py3.6.egg/codemod/base.py", line 79, in run_interactive
    _ask_about_patch(patch, editor, default_no)
  File "/private/tmp/test/lib/python3.6/site-packages/codemod-1.0.0-py3.6.egg/codemod/base.py", line 252, in _ask_about_patch
    terminal.terminal_clear()
  File "/private/tmp/test/lib/python3.6/site-packages/codemod-1.0.0-py3.6.egg/codemod/terminal_helper.py", line 55, in terminal_clear
    if not _terminal_use_capability('clear'):
  File "/private/tmp/test/lib/python3.6/site-packages/codemod-1.0.0-py3.6.egg/codemod/terminal_helper.py", line 75, in _terminal_use_capability
    sys.stdout.write(unicode(capability, 'ascii'))
NameError: name 'unicode' is not defined
```
- Make happy test suite in python3.x because of doctest `print` statement issue
- Add python3.x stable version in the travis ci-configuration

**Tests verification should be ok after that change**

- python2.x:

```
(codemod-2.7) % make test
py.test --doctest-modules codemod
========================== test session starts  =============
platform darwin -- Python 2.7.14, pytest-3.8.2, py-1.6.0, pluggy-0.7.1
rootdir: /Users/sbrabez/github/codemod, inifile: pytest.ini
collected 18 items

codemod/base.py .                                                                                                                                                                                                                                                        [  5%]
codemod/helpers.py ...                                                                                                                                                                                                                                                   [ 22%]
codemod/patch.py .                                                                                                                                                                                                                                                       [ 27%]
codemod/position.py .                                                                                                                                                                                                                                                    [ 33%]
codemod/query.py ...                                                                                                                                                                                                                                                     [ 50%]
codemod/base.py .                                                                                                                                                                                                                                                        [ 50%]
codemod/helpers.py ...                                                                                                                                                                                                                                                   [ 50%]
codemod/patch.py .                                                                                                                                                                                                                                                       [ 50%]
codemod/position.py .                                                                                                                                                                                                                                                    [ 50%]
codemod/query.py ...

18 passed in 0.12 seconds
```

- python3.x

```
(codemod-3.6) % make test
py.test --doctest-modules codemod
========================== test session starts  =============
platform darwin -- Python 3.6.5, pytest-3.8.2, py-1.6.0, pluggy-0.7.1
rootdir: /Users/sbrabez/github/codemod, inifile: pytest.ini
collected 18 items

codemod/base.py .                                                                                                                                                                                                                                                        [  5%]
codemod/helpers.py ...                                                                                                                                                                                                                                                   [ 22%]
codemod/patch.py .                                                                                                                                                                                                                                                       [ 27%]
codemod/position.py .                                                                                                                                                                                                                                                    [ 33%]
codemod/query.py ...                                                                                                                                                                                                                                                     [ 50%]
codemod/base.py .                                                                                                                                                                                                                                                        [ 50%]
codemod/helpers.py ...                                                                                                                                                                                                                                                   [ 50%]
codemod/patch.py .                                                                                                                                                                                                                                                       [ 50%]
codemod/position.py .                                                                                                                                                                                                                                                    [ 50%]
codemod/query.py ...

18 passed in 0.13 seconds
```

Thank you for this awesome project to help refactoring huge code base!

I hack on this change for [Hacktoberfest](https://hacktoberfest.digitalocean.com), please let me know your feedback.