### PR TITLE
Handle anchors in multiline mode

### DIFF
--- a/codemod/base.py
+++ b/codemod/base.py
@@ -150,9 +150,9 @@ def multiline_regex_suggestor(regex, substitution=None, ignore_case=False):
     """
     if isinstance(regex, str):
         if ignore_case is False:
-            regex = re.compile(regex, re.DOTALL)
+            regex = re.compile(regex, re.DOTALL | re.MULTILINE)
         else:
-            regex = re.compile(regex, re.DOTALL | re.IGNORECASE)
+            regex = re.compile(regex, re.DOTALL | re.MULTILINE | re.IGNORECASE)
 
     if isinstance(substitution, str):
         def substitution_func(match):


### PR DESCRIPTION
Use the [`MULTILINE` flag](https://docs.python.org/2/library/re.html#re.MULTILINE) with `re.compile()` when the `-m` option is passed. This enables the use of `^` and `$` in multiline mode.